### PR TITLE
Add govdelivery support

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -84,6 +84,15 @@ urlpatterns = [
                                            default_template='sub-pages/_single.html',),name='detail')
     ], namespace='sub_page')),
     url(r'^activity-log/$', TemplateView.as_view(template_name='activity-log/index.html'), name='activity-log'),
+
+    url(r'^subscriptions/new/$', 'core.views.govdelivery_subscribe', name='govdelivery'),
+    url(r'^govdelivery-subscribe/', include([
+        url(r'^success/$', TemplateView.as_view(template_name='govdelivery-subscribe/success/index.html'), name='success'),
+        url(r'^error/$', TemplateView.as_view(template_name='govdelivery-subscribe/error/index.html'), name='user_error'),
+        url(r'^server-error/$', TemplateView.as_view(template_name='govdelivery-subscribe/server-error/index.html'), name='server_error'),
+
+      ], namespace='govdelivery'))
+
 ]
 
 from sheerlike import register_permalink

--- a/cfgov/core/tests.py
+++ b/cfgov/core/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -1,0 +1,25 @@
+import unittest
+
+from core.utils import extract_answers_from_request
+
+
+class FakeRequest(object):
+    # Quick way to simulate a request object with a POST attribute
+    def __init__(self, params):
+        self.POST = params
+
+
+class ExtractAnswersTest(unittest.TestCase):
+
+    def test_no_answers_to_extract(self):
+        request = FakeRequest({'unrelated_key': 'unrelated_value'})
+        result = extract_answers_from_request(request)
+        assert result == []
+
+    def test_multiple_answers_to_extract(self):
+        request = FakeRequest({'unrelated_key': 'unrelated_value',
+                               'questionid_first': 'some_answer',
+                               'questionid_another': 'another_answer'})
+        result = extract_answers_from_request(request)
+        assert result == [('first', 'some_answer'),
+                          ('another', 'another_answer')]

--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -1,0 +1,78 @@
+import json
+from mock import call, patch
+
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+
+class GovDeliverySubscribeTest(TestCase):
+
+    def test_missing_email_address(self):
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE'})
+        self.assertRedirects(response, reverse('govdelivery:user_error'))
+
+    def test_missing_gd_code(self):
+        response = self.client.post(reverse('govdelivery'),
+                                    {'email': 'fake@email.com'})
+        self.assertRedirects(response, reverse('govdelivery:user_error'))
+
+    def test_missing_email_address_ajax(self):
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.content, json.dumps({'result': 'fail'}))
+
+    def test_missing_gd_code_ajax(self):
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.content, json.dumps({'result': 'fail'}))
+
+    @patch('core.views.GovDelivery.set_subscriber_topics')
+    def test_successful_subscribe(self, mock_gd):
+        mock_gd.return_value.status_code = 200
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE',
+                                     'email': 'fake@email.com'})
+        mock_gd.assert_called_with('fake@email.com',
+                                   ['FAKE_CODE'])
+        self.assertRedirects(response, reverse('govdelivery:success'))
+
+    @patch('core.views.GovDelivery.set_subscriber_topics')
+    def test_successful_subscribe_ajax(self, mock_gd):
+        mock_gd.return_value.status_code = 200
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE',
+                                     'email': 'fake@email.com'},
+                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        mock_gd.assert_called_with('fake@email.com',
+                                   ['FAKE_CODE'])
+        self.assertEqual(response.content, json.dumps({'result': 'pass'}))
+
+    @patch('core.views.GovDelivery.set_subscriber_topics')
+    def test_server_error(self, mock_gd):
+        mock_gd.return_value.status_code = 500
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE',
+                                     'email': 'fake@email.com'})
+        mock_gd.assert_called_with('fake@email.com',
+                                   ['FAKE_CODE'])
+        self.assertRedirects(response, reverse('govdelivery:server_error'))
+
+    @patch('core.views.GovDelivery.set_subscriber_topics')
+    @patch('core.views.GovDelivery.set_subscriber_answers_to_question')
+    def test_setting_subscriber_answers_to_questions(self,
+                                                     mock_set_answers,
+                                                     mock_set_topics):
+        mock_set_topics.return_value.status_code = 200
+        mock_set_answers.return_value.status_code = 200
+        response = self.client.post(reverse('govdelivery'),
+                                    {'code': 'FAKE_CODE',
+                                     'email': 'fake@email.com',
+                                     'questionid_batman': 'robin',
+                                     'questionid_hello': 'goodbye'})
+        calls = [call('fake@email.com', 'batman', 'robin'),
+                 call('fake@email.com', 'hello', 'goodbye')]
+        mock_set_answers.assert_has_calls(calls)
+        assert mock_set_answers.call_count == 2

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -1,0 +1,4 @@
+def extract_answers_from_request(request):
+    answers = [(param.split('_')[1], value) for param, value in
+               request.POST.items() if param.startswith('questionid')]
+    return answers

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -1,3 +1,46 @@
-from django.shortcuts import render
+import os
 
-# Create your views here.
+from django.views.decorators.http import require_http_methods
+from django.shortcuts import redirect
+from django.http import JsonResponse
+from govdelivery.api import GovDelivery
+
+from core.utils import extract_answers_from_request
+
+ACCOUNT_CODE = os.environ.get('GOVDELIVERY_ACCOUNT_CODE')
+REQUIRED_PARAMS = ['email', 'code']
+
+
+@require_http_methods(['POST'])
+def govdelivery_subscribe(request):
+    """
+    View that checks to see if the request is AJAX, attempts to subscribe
+    the user, then either redirects to an error/success page (non-AJAX) or
+    in the case of AJAX, returns some JSON to tell the front-end.
+    """
+    is_ajax = request.is_ajax()
+    if is_ajax:
+        passing_response = JsonResponse({'result': 'pass'})
+        failing_response = JsonResponse({'result': 'fail'})
+    else:
+        passing_response = redirect('govdelivery:success')
+        failing_response = redirect('govdelivery:server_error')
+    for required_param in REQUIRED_PARAMS:
+        if required_param not in request.POST or not request.POST[required_param]:
+            return failing_response if is_ajax else \
+                redirect('govdelivery:user_error')
+    email_address = request.POST['email']
+    codes = request.POST.getlist('code')
+    gd = GovDelivery(account_code=ACCOUNT_CODE)
+    try:
+        subscription_response = gd.set_subscriber_topics(email_address, codes)
+        if subscription_response.status_code != 200:
+            return failing_response
+    except Exception:
+        return failing_response
+    answers = extract_answers_from_request(request)
+    for question_id, answer_text in answers:
+        response = gd.set_subscriber_answers_to_question(email_address,
+                                                         question_id,
+                                                         answer_text)
+    return passing_response

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ git+https://github.com/cfpb/django-sheerlike.git#egg=sheerlike
 six==1.9.0
 python-dateutil==2.4.2
 requests
+git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery
+mock==1.3.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,4 +5,3 @@ six==1.9.0
 python-dateutil==2.4.2
 requests
 git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery
-mock==1.3.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,0 +1,1 @@
+-r base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,2 @@
+-r base.txt
+mock==1.3.0


### PR DESCRIPTION
Govdelivery is now available in cfgov-django!

You'll need to run `pip install -r requirements/local.txt`.

To test: `python manage.py test`

To actually try the subscription, this hidden input needs to be added to [this form group](https://github.com/cfpb/cfgov-refresh/blob/flapjack/src/_includes/macros/subscribe.html#L37) (will open a separate PR): 

`<input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">`

Review: @rosskarchner @kurtw 
