### PR TITLE
Added tox, mocks, some python 3 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Right now, we're using this project to experiment with different configuration i
 
 Our initial target is Python 2.7 and Django 1.8.
 
+## Tests
+
+To run the test suite, simply run `tox` from the project root.
+
 ## Getting help
 
 If you have questions, concerns, bug reports, etc, please file an issue in this repository's Issue Tracker.

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -21,5 +21,5 @@ class ExtractAnswersTest(unittest.TestCase):
                                'questionid_first': 'some_answer',
                                'questionid_another': 'another_answer'})
         result = extract_answers_from_request(request)
-        assert result == [('first', 'some_answer'),
-                          ('another', 'another_answer')]
+        assert sorted(result) == [('another', 'another_answer'),
+                                  ('first', 'some_answer')]

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 -r base.txt
 mock==1.3.0
+tox==2.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py27,py34
+skipsdist = True
+
+[testenv]
+recreate = True
+setenv =
+    GOVDELIVERY_ACCOUNT_CODE = fake_account_code
+deps =
+    -r{toxinidir}/requirements/test.txt
+changedir = {toxinidir}/cfgov
+commands=
+    python manage.py test


### PR DESCRIPTION
This PR adds tox.  To test, you'll need to `pip install -r requirements/test.txt`, then `tox` from the project root.  Based on the tox output, some changes were needed to maintain support in both python 2 and 3.  Tests for 3.4 will fail until https://github.com/rosskarchner/govdelivery/pull/3 is merged.

I also added mo' mocks because there was an unnecessary govdelivery web request occuring during the tests.
