### PR TITLE
Add ICS generation view + urls.py cleanup + django_extensions

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -1,47 +1,15 @@
 from .base import *
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-CFGOV_REFRESH = Path(__file__).ancestor(5).child('cfgov-refresh')
-
 GRUNT_WATCH = [CFGOV_REFRESH]
 
 DEBUG = True
 
-
 ALLOWED_HOSTS = ['*']
 
-# Application definition
-
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
-
-
-# Internationalization
-# https://docs.djangoproject.com/en/1.8/topics/i18n/
-
-LANGUAGE_CODE = 'en-us'
-
-TIME_ZONE = 'UTC'
-
-USE_I18N = True
-
-USE_L10N = True
-
-USE_TZ = True
-
-
 STATIC_URL = '/static/'
-
 
 SHEER_SITES = [CFGOV_REFRESH.child('dist')]
 SHEER_ELASTICSEARCH_SERVER = 'localhost:9200'
 SHEER_ELASTICSEARCH_INDEX = 'content'
-
 
 INSTALLED_APPS += ('django_extensions',)

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -36,11 +36,12 @@ USE_L10N = True
 USE_TZ = True
 
 
-
 STATIC_URL = '/static/'
 
 
-
-SHEER_SITES=[CFGOV_REFRESH.child('dist')]
+SHEER_SITES = [CFGOV_REFRESH.child('dist')]
 SHEER_ELASTICSEARCH_SERVER = 'localhost:9200'
 SHEER_ELASTICSEARCH_INDEX = 'content'
+
+
+INSTALLED_APPS += ('django_extensions',)

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,0 +1,1 @@
+from .base import *

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import include, url
-from django.contrib import admin
-from django.views.generic.base import RedirectView, TemplateView
+from django.views.generic.base import TemplateView
 from sheerlike.views.generic import SheerTemplateView
 from sheerlike.feeds import SheerlikeFeed
 
@@ -9,34 +8,39 @@ from flapjack.views import LeadershipCalendarPDFView
 
 urlpatterns = [
     url(r'^$', SheerTemplateView.as_view(), name='home'),
-    
+
     url(r'^blog/', include([
         url(r'^$', TemplateView.as_view(template_name='blog/index.html'),
-                   name='index'), 
+            name='index'),
         url(r'^(?P<doc_id>[\w-]+)/$',
-                   SheerTemplateView.as_view(doc_type='posts',
-                                           local_name='post',
-                                           default_template='blog/_single.html',),
-                   name='detail'),], namespace='blog')),
+            SheerTemplateView.as_view(doc_type='posts',
+                                      local_name='post',
+                                      default_template='blog/_single.html'),
+            name='detail')],
+        namespace='blog')),
 
     url(r'^newsroom/', include([
         url(r'^$', TemplateView.as_view(template_name='newsroom/index.html'),
-                   name='index'), 
+            name='index'),
         url(r'^press-resources/$',
-            TemplateView.as_view(template_name='newsroom/press-resources/index.html'),
+            TemplateView.as_view(
+                template_name='newsroom/press-resources/index.html'),
             name='press-resources'),
         url(r'^(?P<doc_id>[\w-]+)/$',
-                   SheerTemplateView.as_view(doc_type='newsroom',
-                                           local_name='newsroom',
-                                           default_template='newsroom/_single.html',),
-                   name='detail'),], namespace='newsroom')),
+            SheerTemplateView.as_view(doc_type='newsroom',
+                                      local_name='newsroom',
+                                      default_template='newsroom/_single.html'),
+            name='detail')],
+        namespace='newsroom')),
 
-    url(r'^budget/',include([
-        url(r'^$', TemplateView.as_view(template_name='budget/index.html'), name='home'),
+    url(r'^budget/', include([
+        url(r'^$',
+            TemplateView.as_view(template_name='budget/index.html'),
+            name='home'),
         url(r'^(?P<page_slug>[\w-]+)/$',
             SheerTemplateView.as_view(),
-            name='page'), 
-        ], namespace="budget")),
+            name='page')],
+        namespace="budget")),
 
     url(r'^the-bureau/', include([
         url(r'^$', SheerTemplateView.as_view(template_name='the-bureau/index.html'),
@@ -49,8 +53,8 @@ urlpatterns = [
             name='leadership-calendar-pdf'),
         url(r'^leadership-calendar/print/$',
             SheerTemplateView.as_view(),
-            name='leadership-calendar-print')
-            ], namespace='the-bureau')),
+            name='leadership-calendar-print')],
+        namespace='the-bureau')),
 
     url(r'^doing-business-with-us/', include([
         url(r'^$',
@@ -58,50 +62,65 @@ urlpatterns = [
             name='index'),
         url(r'^(?P<page_slug>[\w-]+)/$',
             SheerTemplateView.as_view(),
-            name='page'),
-
-    ], namespace='business')),
+            name='page')],
+        namespace='business')),
 
     url(r'^contact-us/', include([
         url(r'^$',
             TemplateView.as_view(template_name='contact-us/index.html'),
-            name='index'),
-
-    ], namespace='contact-us')),
+            name='index')],
+        namespace='contact-us')),
 
     url(r'^events/', include([
         url(r'^$', TemplateView.as_view(template_name='events/index.html'),
             name='events'),
         url(r'^(?P<doc_id>[\w-]+)/$',
-                   SheerTemplateView.as_view(doc_type='events',
-                                           local_name='event',
-                                           default_template='events/_single.html',),name='event_archive')
-    ])),
+            SheerTemplateView.as_view(doc_type='events',
+                                      local_name='event',
+                                      default_template='events/_single.html'),
+            name='event_archive')]
+        )),
 
     url(r'^offices/', include([
         url(r'^(?P<doc_id>[\w-]+)/$',
-                   SheerTemplateView.as_view(doc_type='office',
-                                           local_name='office',
-                                           default_template='offices/_single.html',),name='detail')
-    ], namespace='offices')),
+            SheerTemplateView.as_view(doc_type='office',
+                                      local_name='office',
+                                      default_template='offices/_single.html',),
+            name='detail')],
+        namespace='offices')),
 
     url(r'^sub-pages/', include([
         url(r'^(?P<doc_id>[\w-]+)/$',
-                   SheerTemplateView.as_view(doc_type='sub_page',
-                                           local_name='sub_page',
-                                           default_template='sub-pages/_single.html',),name='detail')
-    ], namespace='sub_page')),
-    url(r'^activity-log/$', TemplateView.as_view(template_name='activity-log/index.html'), name='activity-log'),
+            SheerTemplateView.as_view(doc_type='sub_page',
+                                      local_name='sub_page',
+                                      default_template='sub-pages/_single.html'),
+            name='detail')],
+        namespace='sub_page')),
 
-    url(r'^subscriptions/new/$', 'core.views.govdelivery_subscribe', name='govdelivery'),
+    url(r'^activity-log/$',
+        TemplateView.as_view(template_name='activity-log/index.html'),
+        name='activity-log'),
+
+    url(r'^subscriptions/new/$',
+        'core.views.govdelivery_subscribe',
+        name='govdelivery'),
+
     url(r'^govdelivery-subscribe/', include([
-        url(r'^success/$', TemplateView.as_view(template_name='govdelivery-subscribe/success/index.html'), name='success'),
-        url(r'^error/$', TemplateView.as_view(template_name='govdelivery-subscribe/error/index.html'), name='user_error'),
-        url(r'^server-error/$', TemplateView.as_view(template_name='govdelivery-subscribe/server-error/index.html'), name='server_error'),
+        url(r'^success/$',
+            TemplateView.as_view(
+                template_name='govdelivery-subscribe/success/index.html'),
+            name='success'),
+        url(r'^error/$',
+            TemplateView.as_view(
+                template_name='govdelivery-subscribe/error/index.html'),
+            name='user_error'),
+        url(r'^server-error/$',
+            TemplateView.as_view(
+                template_name='govdelivery-subscribe/server-error/index.html'),
+            name='server_error')],
+        namespace='govdelivery')),
 
-      ], namespace='govdelivery')),
     url(r'^feed/(?P<doc_type>[\w-]+)/$', SheerlikeFeed(), name='feed'),
-
 ]
 
 from sheerlike import register_permalink

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -3,7 +3,7 @@ from django.views.generic.base import TemplateView
 from sheerlike.views.generic import SheerTemplateView
 from sheerlike.feeds import SheerlikeFeed
 
-from flapjack.views import LeadershipCalendarPDFView
+from flapjack.views import LeadershipCalendarPDFView, EventICSView
 
 
 urlpatterns = [
@@ -78,8 +78,9 @@ urlpatterns = [
             SheerTemplateView.as_view(doc_type='events',
                                       local_name='event',
                                       default_template='events/_single.html'),
-            name='event_archive')]
-        )),
+            name='event'),
+        url(r'^(?P<doc_id>[\w-]+)/ics/$', EventICSView.as_view())],
+        namespace='events')),
 
     url(r'^offices/', include([
         url(r'^(?P<doc_id>[\w-]+)/$',

--- a/cfgov/core/services.py
+++ b/cfgov/core/services.py
@@ -1,8 +1,14 @@
 import os
 
-from django.views.generic import View
+import requests
+import icalendar
 from django.http import HttpResponse
 from core.lib.PDFreactor import *
+from django.views.generic.base import View, ContextMixin
+from django.http import HttpResponse, Http404
+from django.core.exceptions import ImproperlyConfigured
+from pytz import timezone
+from dateutil.parser import parse
 
 
 class PDFGeneratorView(View):
@@ -61,3 +67,119 @@ class PDFGeneratorView(View):
 
     def get(self, *args, **kwargs):
         return self.generate_pdf()
+
+
+class ICSView(ContextMixin, View):
+    """
+    Returns an .ics file for a given calendar event
+    """
+    # Contants
+    event_calendar_prodid = '-//CFPB//Calendar Item//EN',
+    event_source = None
+
+    # Default variables
+    event_summary = ''
+    event_dtstart = '2015-01-01T00:00:00'
+    event_dtend = '2015-01-01T00:00:00'
+    event_dtstamp = '2015-01-01T00:00:00'
+    event_uid = ''
+    event_priority = 1
+    event_organizer = ''
+    event_organizer_addr = ''
+    event_location = ''
+    event_status = 'TENTATIVE'
+
+    def get_event_source(self):
+        if self.event_source is None:
+            raise ImproperlyConfigured(
+                "ICSView requires an 'event_source' to be set.")
+        return self.event_source
+
+    def get_event_json(self, event_slug):
+        source_template = self.get_event_source()
+        source_url = source_template.replace('<event_slug>', event_slug)
+        source_response = requests.get(source_url)
+        try:
+            self.event_json = source_response.json()['ics']
+        except ValueError:
+            self.event_json = {}
+        return source_response.status_code
+
+    def get_field_value(self, attribute):
+        """
+        Check if the attribute keyname was passed in; if so, get the value
+        Otherwise, use the default attribute on this base class
+        """
+        attribute_variable = "{}_keyname".format(attribute)
+        try:
+            attribute_value = getattr(self, attribute_variable)
+            return self.event_json.get(attribute_value, '')
+        except AttributeError:
+            attribute_value = getattr(self, attribute)
+        return attribute_value
+
+    def make_date_tz_aware(self, date, tzinfo_field):
+        """
+        Convert datetime-naive date to a datetime-aware date
+        Specifically setting a location/TZ like this is required by icalendar
+        """
+        naive_date = parse(date)
+        if self.event_json.get(tzinfo_field):
+            tzname = self.event_json[tzinfo_field]
+            aware_date = naive_date.astimezone(timezone(tzname))
+        else:
+            aware_date = timezone('UTC').localize(naive_date)
+        return aware_date
+
+    def generate_ics(self, event_slug):
+        # Get the event json from our source
+        source_status = self.get_event_json(event_slug)
+        if source_status != 200:
+            return HttpResponse('', status=source_status)
+
+        # Create the Calendar
+        calendar = icalendar.Calendar()
+        calendar.add('prodid', self.event_calendar_prodid)
+        calendar.add('version', '2.0')
+        calendar.add('method', 'publish')
+
+        # Create the event
+        event = icalendar.Event()
+
+         # Populate the event
+        event.add('summary', self.get_field_value('event_summary'))
+        event.add('uid', self.get_field_value('event_uid'))
+        event.add('location', self.get_field_value('event_location'))
+        dtstart = self.make_date_tz_aware(self.get_field_value('event_dtstart'),
+                                          'starting_tzidnfo')
+        dtend = self.make_date_tz_aware(self.get_field_value('event_dtend'),
+                                        'ending_tzidnfo')
+        event.add('dtstart', dtstart)
+        event.add('dtend', dtend)
+        event.add('dtstamp', parse(self.get_field_value('event_dtstamp')))
+        event.add('status', self.get_field_value('event_status'))
+
+        # Create any persons associated with the event
+        if self.get_field_value('event_organizer_addr') and \
+            self.get_field_value('event_organizer'):
+            organizer = icalendar.vCalAddress(
+                'MAILTO:' + self.get_field_value('event_organizer_addr'))
+            organizer.params['cn'] = icalendar.vText(
+                self.get_field_value('event_organizer'))
+            event.add('organizer', organizer)
+
+        # Add the event to the calendar
+        calendar.add_component(event)
+
+        # Return the ICS formatted calendar
+        response = HttpResponse(calendar.to_ical(),
+                                content_type='text/calendar',
+                                status=source_status,
+                                charset='utf-8')
+        response['Content-Disposition'] = 'attachment;filename={}.ics'.format(
+            event_slug)
+        return response
+
+    def get(self, *args, **kwargs):
+        event_slug = kwargs.get('doc_id')
+        return self.generate_ics(event_slug) if event_slug else Http404

--- a/cfgov/core/services.py
+++ b/cfgov/core/services.py
@@ -1,14 +1,18 @@
 import os
 
+import six
 import requests
 import icalendar
-from django.http import HttpResponse
-from core.lib.PDFreactor import *
 from django.views.generic.base import View, ContextMixin
 from django.http import HttpResponse, Http404
 from django.core.exceptions import ImproperlyConfigured
 from pytz import timezone
 from dateutil.parser import parse
+
+# PDFreactor's python wrapper doesn't support python 3, so neither can we for
+# now.
+if six.PY2:
+    from core.lib.PDFreactor import *
 
 
 class PDFGeneratorView(View):
@@ -161,7 +165,7 @@ class ICSView(ContextMixin, View):
 
         # Create any persons associated with the event
         if self.get_field_value('event_organizer_addr') and \
-            self.get_field_value('event_organizer'):
+                self.get_field_value('event_organizer'):
             organizer = icalendar.vCalAddress(
                 'MAILTO:' + self.get_field_value('event_organizer_addr'))
             organizer.params['cn'] = icalendar.vText(

--- a/cfgov/core/tests/test_services.py
+++ b/cfgov/core/tests/test_services.py
@@ -1,0 +1,75 @@
+import mock
+import icalendar
+from django.test import TestCase
+
+from core.services import ICSView
+
+
+class ICSViewTest(TestCase):
+
+    def setUp(self):
+        pass
+
+    @mock.patch('requests.get')
+    def test_get_event_json(self, mock_request_get):
+        """
+        Test that we're constructing the event source URL from which to fetch
+        JSON correctly.
+        """
+        # We want two possible responses, first a good, 200 response, and
+        # then a 404 response (a response that doesn't provide JSON). We
+        # need to make sure we're handling the ValueError (JSONDecodeError).
+        mock_good_response = mock.MagicMock()
+        mock_good_response.status_code = 200
+        mock_good_response.json.return_value = {'ics': {'some': 'json'}}
+
+        mock_bad_response = mock.MagicMock()
+        mock_bad_response.status_code = 404
+        mock_bad_response.json.side_effect = ValueError()
+
+        mock_request_get.side_effect = [
+            mock_good_response,
+            mock_bad_response
+        ]
+        view = ICSView(
+            event_source='http://localhost:9200/events/<event_slug>/')
+
+        source_status = view.get_event_json('myevent')
+        self.assertEqual(source_status, 200)
+        mock_request_get.assert_called_with(
+            'http://localhost:9200/events/myevent/')
+
+        source_status = view.get_event_json('myevent')
+        self.assertEqual(source_status, 404)
+        self.assertEqual(view.event_json, {})
+
+    def test_generate_ics(self):
+        """
+        Test that, given a specific set of JSON, the generate_ics
+        function generates valid iCalendar data.
+        """
+        view = ICSView(
+            event_source='http://localhost:9200/events/<event_slug>/')
+        view.event_json = {
+            'ics': {
+                'summary': 'Test Event',
+                'location': 'Washington, DC',
+                'uid': '8DB71F484FA2ABC57F621CB7F1@2013-07-03 09:30:00',
+                'dtstart': '2015-07-01T05:00:00-04:00',
+                'starting_tzinfo': 'America/New_York',
+                'dtend': '2015-07-01T06:00:00-04:00',
+                'ending_tzinfo': 'America/New_York',
+                'dtstamp': '2013-07-02T14:29:08'
+            }
+        }
+
+        with mock.patch('core.services.ICSView.get_event_json') as \
+                mock_get_event_json:
+            mock_get_event_json.return_value = 200
+            response = view.generate_ics('foo')
+
+            # Make sure the ics parses
+            try:
+                icalendar.Calendar.from_ical(response.content)
+            except ValueError:
+                self.fail('generate_ics() did not return a valid iCalendar file')

--- a/cfgov/flapjack/views.py
+++ b/cfgov/flapjack/views.py
@@ -1,7 +1,28 @@
-from core.services import PDFGeneratorView
+from core.services import PDFGeneratorView, ICSView
 
 
 class LeadershipCalendarPDFView(PDFGeneratorView):
     render_url = 'http://localhost/the-bureau/leadership-calendar/print/'
     stylesheet_url = 'http://localhost/static/css/pdfreactor-fonts.css'
     filename = 'cfpb_leadership-calendar.pdf'
+
+
+class EventICSView(ICSView):
+    """
+    View for ICS generation in the /events/ section
+    """
+    # Constants
+    event_calendar_prodid = '-//CFPB//Event Calendar//EN',
+    event_source = 'http://localhost:9200/content/events/<event_slug>/_source'
+
+    # JSON key names
+    event_summary_keyname = 'summary'
+    event_dtstart_keyname = 'dtstart'
+    event_dtend_keyname = 'dtend'
+    event_dtstamp_keyname = 'dtstamp'
+    event_uid_keyname = 'uid'
+    event_priority_keyname = 'priority'
+    event_organizer_keyname = 'organizer'
+    event_organizer_addr_keyname = 'organizer_email'
+    event_location_keyname = 'location'
+    event_status_keyname = 'status'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ six==1.9.0
 python-dateutil==2.4.2
 requests
 git+https://github.com/rosskarchner/govdelivery.git#egg=govdelivery
+icalendar==3.9.0

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,1 +1,3 @@
 -r base.txt
+django-extensions==1.5.5
+Werkzeug==0.10.4

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skipsdist = True
 recreate = True
 setenv =
     GOVDELIVERY_ACCOUNT_CODE = fake_account_code
+    DJANGO_SETTINGS_MODULE = cfgov.settings.test
 deps =
     -r{toxinidir}/requirements/test.txt
 changedir = {toxinidir}/cfgov


### PR DESCRIPTION
1. Adds support for ICS generation.  There's a base view in /core/services and a view that subclasses it in /flapjack/views.
2. Cleaned up urls.py
3. Added [django_extensions](http://django-extensions.readthedocs.org/en/latest/) and werkzeug to local settings and requirements so we get the widely used and often convenient runserver_plus, shell_plus, etc.
